### PR TITLE
dynamic builders

### DIFF
--- a/Assets/Example.cs
+++ b/Assets/Example.cs
@@ -30,4 +30,5 @@ public struct ExampleBlob
     [CustomBuilder(typeof(ObjectName))] public BlobString GameObjectName;
     public AnimationCurveBlob AnimationCurve;
     public ComponentType.AccessMode Enum;
+    public BlobArray<BlobArray<BlobArray<BlobPtr<BlobString>>>> Arrays;
 }

--- a/Assets/Example.cs
+++ b/Assets/Example.cs
@@ -29,6 +29,5 @@ public struct ExampleBlob
     public Guid Guid;
     [CustomBuilder(typeof(ObjectName))] public BlobString GameObjectName;
     public AnimationCurveBlob AnimationCurve;
+    public ComponentType.AccessMode Enum;
 }
-
-public class ExampleBlobBuilder : BlobDataBuilder<ExampleBlob> {}

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 705507994}
-  m_IndirectSpecularColor: {r: 0.44657815, g: 0.49641192, b: 0.57481617, a: 1}
+  m_IndirectSpecularColor: {r: 0.44657874, g: 0.49641258, b: 0.5748171, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -334,9 +334,12 @@ MonoBehaviour:
   StringArray:
     Builder:
       id: 1
-  AnimationCurve:
+  StringArrayArray:
     Builder:
       id: 2
+  AnimationCurve:
+    Builder:
+      id: 3
   references:
     version: 1
     00000000:
@@ -347,9 +350,19 @@ MonoBehaviour:
       type: {class: StringArrayBuilder, ns: Blob, asm: Blob.Builder}
       data:
         Value:
-        - id: 3
         - id: 4
+        - id: 5
     00000002:
+      type: {class: DynamicArrayBuilder, ns: Blob, asm: Blob.Builder}
+      data:
+        ArrayElementType: Unity.Entities.BlobArray`1[[Unity.Entities.BlobPtr`1[[Unity.Entities.BlobString,
+          Unity.Entities, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null]],
+          Unity.Entities, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null]],
+          Unity.Entities, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+        Value:
+        - id: 6
+        - id: 7
+    00000003:
       type: {class: AnimationCurveBlobBuilder, ns: Blob, asm: Blob.Builder}
       data:
         Value:
@@ -376,14 +389,78 @@ MonoBehaviour:
           m_PreInfinity: 2
           m_PostInfinity: 2
           m_RotationOrder: 4
-    00000003:
-      type: {class: StringBuilder, ns: Blob, asm: Blob.Builder}
-      data:
-        Value: aaa
     00000004:
       type: {class: StringBuilder, ns: Blob, asm: Blob.Builder}
       data:
+        Value: aaa
+    00000005:
+      type: {class: StringBuilder, ns: Blob, asm: Blob.Builder}
+      data:
         Value: bbbb
+    00000006:
+      type: {class: DynamicArrayBuilder, ns: Blob, asm: Blob.Builder}
+      data:
+        ArrayElementType: Unity.Entities.BlobPtr`1[[Unity.Entities.BlobString, Unity.Entities,
+          Version=0.0.0.0, Culture=neutral, PublicKeyToken=null]], Unity.Entities,
+          Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+        Value:
+        - id: 8
+        - id: 9
+        - id: 10
+    00000007:
+      type: {class: DynamicArrayBuilder, ns: Blob, asm: Blob.Builder}
+      data:
+        ArrayElementType: Unity.Entities.BlobPtr`1[[Unity.Entities.BlobString, Unity.Entities,
+          Version=0.0.0.0, Culture=neutral, PublicKeyToken=null]], Unity.Entities,
+          Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+        Value:
+        - id: 11
+        - id: 12
+    00000008:
+      type: {class: StringPtrBuilder, ns: Blob, asm: Blob.Builder}
+      data:
+        Value:
+          id: 13
+    00000009:
+      type: {class: StringPtrBuilder, ns: Blob, asm: Blob.Builder}
+      data:
+        Value:
+          id: 14
+    0000000A:
+      type: {class: StringPtrBuilder, ns: Blob, asm: Blob.Builder}
+      data:
+        Value:
+          id: 15
+    0000000B:
+      type: {class: StringPtrBuilder, ns: Blob, asm: Blob.Builder}
+      data:
+        Value:
+          id: 16
+    0000000C:
+      type: {class: StringPtrBuilder, ns: Blob, asm: Blob.Builder}
+      data:
+        Value:
+          id: 17
+    0000000D:
+      type: {class: StringBuilder, ns: Blob, asm: Blob.Builder}
+      data:
+        Value: a
+    0000000E:
+      type: {class: StringBuilder, ns: Blob, asm: Blob.Builder}
+      data:
+        Value: b
+    0000000F:
+      type: {class: StringBuilder, ns: Blob, asm: Blob.Builder}
+      data:
+        Value: c
+    00000010:
+      type: {class: StringBuilder, ns: Blob, asm: Blob.Builder}
+      data:
+        Value: 123
+    00000011:
+      type: {class: StringBuilder, ns: Blob, asm: Blob.Builder}
+      data:
+        Value: 321
 --- !u!4 &1351734626
 Transform:
   m_ObjectHideFlags: 0
@@ -433,8 +510,10 @@ MonoBehaviour:
   references:
     version: 1
     00000000:
-      type: {class: SimpleDataBuilder, ns: , asm: Assembly-CSharp}
+      type: {class: DynamicBlobDataBuilder, ns: Blob, asm: Blob.Builder}
       data:
+        BlobDataType: SimpleData, Assembly-CSharp, Version=0.0.0.0, Culture=neutral,
+          PublicKeyToken=null
         FieldNames:
         - Int
         - String
@@ -445,6 +524,7 @@ MonoBehaviour:
         - StringArray
         - UInt
         - DoublePtr
+        - TestEnum
         Builders:
         - id: 1
         - id: 2
@@ -455,6 +535,7 @@ MonoBehaviour:
         - id: 7
         - id: 8
         - id: 9
+        - id: 10
     00000001:
       type: {class: Int32Builder, ns: Blob.Primitive, asm: Blob.Builder}
       data:
@@ -462,80 +543,75 @@ MonoBehaviour:
     00000002:
       type: {class: StringBuilder, ns: Blob, asm: Blob.Builder}
       data:
-        Value: 222
+        Value: 2222
     00000003:
       type: {class: SingleBuilder, ns: Blob.Primitive, asm: Blob.Builder}
       data:
-        Value: 3
+        Value: 3.3333
     00000004:
       type: {class: Int32ArrayBuilder, ns: Blob.Primitive, asm: Blob.Builder}
       data:
         Value:
-        - id: 10
         - id: 11
         - id: 12
-        - id: 13
     00000005:
       type: {class: Int64Builder, ns: Blob.Primitive, asm: Blob.Builder}
       data:
-        Value: 9
+        Value: 666
     00000006:
       type: {class: UInt64PtrBuilder, ns: Blob.Primitive, asm: Blob.Builder}
       data:
         Value:
-          id: 14
+          id: 13
     00000007:
       type: {class: StringArrayBuilder, ns: Blob, asm: Blob.Builder}
       data:
         Value:
+        - id: 14
         - id: 15
         - id: 16
-        - id: 17
     00000008:
       type: {class: UInt32Builder, ns: Blob.Primitive, asm: Blob.Builder}
       data:
-        Value: 12345
+        Value: 8
     00000009:
       type: {class: DoublePtrBuilder, ns: Blob.Primitive, asm: Blob.Builder}
       data:
         Value:
-          id: 18
+          id: 17
     0000000A:
-      type: {class: Int32Builder, ns: Blob.Primitive, asm: Blob.Builder}
+      type: {class: DynamicIntEnumBuilder, ns: Blob, asm: Blob.Builder}
       data:
-        Value: 5
+        EnumTypeName: Test, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+        Value: 1
     0000000B:
       type: {class: Int32Builder, ns: Blob.Primitive, asm: Blob.Builder}
       data:
-        Value: 6
+        Value: 4
     0000000C:
       type: {class: Int32Builder, ns: Blob.Primitive, asm: Blob.Builder}
       data:
-        Value: 7
+        Value: 5
     0000000D:
-      type: {class: Int32Builder, ns: Blob.Primitive, asm: Blob.Builder}
-      data:
-        Value: 8
-    0000000E:
       type: {class: UInt64Builder, ns: Blob.Primitive, asm: Blob.Builder}
       data:
-        Value: 10
+        Value: 777
+    0000000E:
+      type: {class: StringBuilder, ns: Blob, asm: Blob.Builder}
+      data:
+        Value: aaaa
     0000000F:
       type: {class: StringBuilder, ns: Blob, asm: Blob.Builder}
       data:
-        Value: aaa
+        Value: bbbbb
     00000010:
       type: {class: StringBuilder, ns: Blob, asm: Blob.Builder}
       data:
-        Value: bbb
+        Value: cccc
     00000011:
-      type: {class: StringBuilder, ns: Blob, asm: Blob.Builder}
-      data:
-        Value: ccc
-    00000012:
       type: {class: DoubleBuilder, ns: Blob.Primitive, asm: Blob.Builder}
       data:
-        Value: 67890.12345
+        Value: 999.999
 --- !u!4 &1386176993
 Transform:
   m_ObjectHideFlags: 0
@@ -585,8 +661,10 @@ MonoBehaviour:
   references:
     version: 1
     00000000:
-      type: {class: MathBlobDataBuilder, ns: , asm: Assembly-CSharp}
+      type: {class: DynamicBlobDataBuilder, ns: Blob, asm: Blob.Builder}
       data:
+        BlobDataType: MathData, Assembly-CSharp, Version=0.0.0.0, Culture=neutral,
+          PublicKeyToken=null
         FieldNames:
         - Float3
         - String
@@ -611,13 +689,13 @@ MonoBehaviour:
     00000002:
       type: {class: StringBuilder, ns: Blob, asm: Blob.Builder}
       data:
-        Value: asfdfd
+        Value: 4321
     00000003:
       type: {class: bool2Builder, ns: Blob.Mathematics, asm: Blob.Builder}
       data:
         Value:
-          x: 0
-          y: 1
+          x: 1
+          y: 0
     00000004:
       type: {class: int3ArrayBuilder, ns: Blob.Mathematics, asm: Blob.Builder}
       data:
@@ -629,11 +707,11 @@ MonoBehaviour:
       data:
         Value:
           c0:
-            x: 5
-            y: 7
+            x: 111
+            y: 333
           c1:
-            x: 6
-            y: 8
+            x: 222
+            y: 444
     00000006:
       type: {class: float2PtrBuilder, ns: Blob.Mathematics, asm: Blob.Builder}
       data:
@@ -643,22 +721,22 @@ MonoBehaviour:
       type: {class: int3Builder, ns: Blob.Mathematics, asm: Blob.Builder}
       data:
         Value:
-          x: 3
-          y: 2
-          z: 1
+          x: 4
+          y: 5
+          z: 6
     00000008:
       type: {class: int3Builder, ns: Blob.Mathematics, asm: Blob.Builder}
       data:
         Value:
-          x: 4
+          x: 6
           y: 5
-          z: 6
+          z: 4
     00000009:
       type: {class: float2Builder, ns: Blob.Mathematics, asm: Blob.Builder}
       data:
         Value:
-          x: 10
-          y: 20
+          x: 3
+          y: 4
 --- !u!4 &1534642739
 Transform:
   m_ObjectHideFlags: 0
@@ -708,8 +786,10 @@ MonoBehaviour:
   references:
     version: 1
     00000000:
-      type: {class: CustomBuilderDataBuilder, ns: , asm: Assembly-CSharp}
+      type: {class: DynamicBlobDataBuilder, ns: Blob, asm: Blob.Builder}
       data:
+        BlobDataType: CustomBuilderData, Assembly-CSharp, Version=0.0.0.0, Culture=neutral,
+          PublicKeyToken=null
         FieldNames:
         - Guid
         - StringGuid
@@ -723,11 +803,11 @@ MonoBehaviour:
     00000001:
       type: {class: GuidBuilder, ns: , asm: Assembly-CSharp}
       data:
-        Guid: ff253a7f-e0b8-4c84-8a20-34f1a6da2cc9
+        Guid: 7e9e9354-2f39-4d95-b09e-b5217cb67244
     00000002:
       type: {class: StringGuid, ns: , asm: Assembly-CSharp}
       data:
-        Guid: b4cabe8f-b9bc-4fd9-b576-e1f182e029d7
+        Guid: 04008197-9d9b-4af3-bd61-1ba4011ea9d8
     00000003:
       type: {class: ObjectName, ns: , asm: Assembly-CSharp}
       data:
@@ -737,8 +817,8 @@ MonoBehaviour:
       data:
         GameObjects:
         - {fileID: 1386176991}
+        - {fileID: 1351734624}
         - {fileID: 1534642737}
-        - {fileID: 1805661907}
 --- !u!4 &1645349338
 Transform:
   m_ObjectHideFlags: 0
@@ -788,8 +868,10 @@ MonoBehaviour:
   references:
     version: 1
     00000000:
-      type: {class: ExampleBlobBuilder, ns: , asm: Assembly-CSharp}
+      type: {class: DynamicBlobDataBuilder, ns: Blob, asm: Blob.Builder}
       data:
+        BlobDataType: ExampleBlob, Assembly-CSharp, Version=0.0.0.0, Culture=neutral,
+          PublicKeyToken=null
         FieldNames:
         - Int
         - Float3
@@ -813,18 +895,18 @@ MonoBehaviour:
     00000001:
       type: {class: Int32Builder, ns: Blob.Primitive, asm: Blob.Builder}
       data:
-        Value: 5
+        Value: 1
     00000002:
       type: {class: float3Builder, ns: Blob.Mathematics, asm: Blob.Builder}
       data:
         Value:
-          x: 6
-          y: 7
-          z: 8
+          x: 2
+          y: 3
+          z: 4
     00000003:
       type: {class: StringBuilder, ns: Blob, asm: Blob.Builder}
       data:
-        Value: eeeeee
+        Value: 5
     00000004:
       type: {class: double2ArrayBuilder, ns: Blob.Mathematics, asm: Blob.Builder}
       data:
@@ -846,17 +928,35 @@ MonoBehaviour:
     00000007:
       type: {class: GuidBuilder, ns: , asm: Assembly-CSharp}
       data:
-        Guid: cb21c8d7-be64-4045-9222-90f8098471ab
+        Guid: c0a52acf-55e8-4fe9-86b9-f926d4d9755a
     00000008:
       type: {class: ObjectName, ns: , asm: Assembly-CSharp}
       data:
-        GameObject: {fileID: 0}
+        GameObject: {fileID: 1805661907}
     00000009:
       type: {class: AnimationCurveBlobBuilder, ns: Blob, asm: Blob.Builder}
       data:
         Value:
           serializedVersion: 2
-          m_Curve: []
+          m_Curve:
+          - serializedVersion: 3
+            time: 0
+            value: 0
+            inSlope: 0
+            outSlope: 0
+            tangentMode: 0
+            weightedMode: 0
+            inWeight: 0
+            outWeight: 0
+          - serializedVersion: 3
+            time: 1
+            value: 1
+            inSlope: 2
+            outSlope: 2
+            tangentMode: 0
+            weightedMode: 0
+            inWeight: 0
+            outWeight: 0
           m_PreInfinity: 2
           m_PostInfinity: 2
           m_RotationOrder: 4
@@ -864,30 +964,30 @@ MonoBehaviour:
       type: {class: double2Builder, ns: Blob.Mathematics, asm: Blob.Builder}
       data:
         Value:
-          x: 22
-          y: 33
+          x: 11
+          y: 22
     0000000B:
       type: {class: double2Builder, ns: Blob.Mathematics, asm: Blob.Builder}
       data:
         Value:
-          x: 44
-          y: 55
+          x: 33
+          y: 44
     0000000C:
       type: {class: StringBuilder, ns: Blob, asm: Blob.Builder}
       data:
-        Value: ffff
+        Value: abc
     0000000D:
       type: {class: StringBuilder, ns: Blob, asm: Blob.Builder}
       data:
-        Value: eeee
+        Value: deF
     0000000E:
       type: {class: StringBuilder, ns: Blob, asm: Blob.Builder}
       data:
-        Value: ggggg
+        Value: FFFFF
     0000000F:
       type: {class: Int64Builder, ns: Blob.Primitive, asm: Blob.Builder}
       data:
-        Value: 0
+        Value: 1239
 --- !u!4 &1805661909
 Transform:
   m_ObjectHideFlags: 0
@@ -937,8 +1037,10 @@ MonoBehaviour:
   references:
     version: 1
     00000000:
-      type: {class: ComplexDataBuilder, ns: , asm: Assembly-CSharp}
+      type: {class: DynamicBlobDataBuilder, ns: Blob, asm: Blob.Builder}
       data:
+        BlobDataType: ComplexData, Assembly-CSharp, Version=0.0.0.0, Culture=neutral,
+          PublicKeyToken=null
         FieldNames:
         - A
         - B
@@ -948,8 +1050,10 @@ MonoBehaviour:
         - id: 2
         - id: 3
     00000001:
-      type: {class: SimpleDataBuilder, ns: , asm: Assembly-CSharp}
+      type: {class: DynamicBlobDataBuilder, ns: Blob, asm: Blob.Builder}
       data:
+        BlobDataType: SimpleData, Assembly-CSharp, Version=0.0.0.0, Culture=neutral,
+          PublicKeyToken=null
         FieldNames:
         - Int
         - String
@@ -971,8 +1075,10 @@ MonoBehaviour:
         - id: 11
         - id: 12
     00000002:
-      type: {class: SimpleData2Builder, ns: , asm: Assembly-CSharp}
+      type: {class: DynamicBlobDataBuilder, ns: Blob, asm: Blob.Builder}
       data:
+        BlobDataType: SimpleData2, Assembly-CSharp, Version=0.0.0.0, Culture=neutral,
+          PublicKeyToken=null
         FieldNames:
         - Int
         - Int2Array
@@ -984,8 +1090,10 @@ MonoBehaviour:
         - id: 15
         - id: 16
     00000003:
-      type: {class: MathBlobDataBuilder, ns: , asm: Assembly-CSharp}
+      type: {class: DynamicBlobDataBuilder, ns: Blob, asm: Blob.Builder}
       data:
+        BlobDataType: MathData, Assembly-CSharp, Version=0.0.0.0, Culture=neutral,
+          PublicKeyToken=null
         FieldNames:
         - Float3
         - String
@@ -1003,7 +1111,7 @@ MonoBehaviour:
     00000004:
       type: {class: Int32Builder, ns: Blob.Primitive, asm: Blob.Builder}
       data:
-        Value: 111
+        Value: 1
     00000005:
       type: {class: StringBuilder, ns: Blob, asm: Blob.Builder}
       data:
@@ -1011,68 +1119,66 @@ MonoBehaviour:
     00000006:
       type: {class: SingleBuilder, ns: Blob.Primitive, asm: Blob.Builder}
       data:
-        Value: 3333
+        Value: 3
     00000007:
       type: {class: Int32ArrayBuilder, ns: Blob.Primitive, asm: Blob.Builder}
       data:
         Value:
         - id: 23
         - id: 24
-        - id: 25
     00000008:
       type: {class: Int64Builder, ns: Blob.Primitive, asm: Blob.Builder}
       data:
-        Value: 222333
+        Value: 66
     00000009:
       type: {class: UInt64PtrBuilder, ns: Blob.Primitive, asm: Blob.Builder}
       data:
         Value:
-          id: 26
+          id: 25
     0000000A:
       type: {class: StringArrayBuilder, ns: Blob, asm: Blob.Builder}
       data:
         Value:
-        - id: 27
-        - id: 28
+        - id: 26
     0000000B:
       type: {class: UInt32Builder, ns: Blob.Primitive, asm: Blob.Builder}
       data:
-        Value: 10101
+        Value: 88
     0000000C:
       type: {class: DoublePtrBuilder, ns: Blob.Primitive, asm: Blob.Builder}
       data:
         Value:
-          id: 29
+          id: 27
     0000000D:
       type: {class: Int32Builder, ns: Blob.Primitive, asm: Blob.Builder}
       data:
-        Value: 3030333
+        Value: 123
     0000000E:
       type: {class: int2ArrayBuilder, ns: Blob.Mathematics, asm: Blob.Builder}
       data:
         Value:
-        - id: 30
-        - id: 31
+        - id: 28
+        - id: 29
     0000000F:
       type: {class: StringBuilder, ns: Blob, asm: Blob.Builder}
       data:
-        Value: rutugj
+        Value: fefdfdas
     00000010:
       type: {class: int3PtrBuilder, ns: Blob.Mathematics, asm: Blob.Builder}
       data:
         Value:
-          id: 32
+          id: 30
     00000011:
       type: {class: float3Builder, ns: Blob.Mathematics, asm: Blob.Builder}
       data:
         Value:
-          x: 45
-          y: 678
-          z: 9
+          x: 1
+          y: 2
+          z: 3
     00000012:
       type: {class: StringBuilder, ns: Blob, asm: Blob.Builder}
       data:
-        Value: ruifdlk
+        Value: ytstgtre
     00000013:
       type: {class: bool2Builder, ns: Blob.Mathematics, asm: Blob.Builder}
       data:
@@ -1083,90 +1189,74 @@ MonoBehaviour:
       type: {class: int3ArrayBuilder, ns: Blob.Mathematics, asm: Blob.Builder}
       data:
         Value:
-        - id: 33
-        - id: 34
+        - id: 31
     00000015:
       type: {class: double2x2Builder, ns: Blob.Mathematics, asm: Blob.Builder}
       data:
         Value:
           c0:
-            x: 33
-            y: 55
+            x: 321
+            y: 456
           c1:
-            x: 44
-            y: 66
+            x: 123
+            y: 7889
     00000016:
       type: {class: float2PtrBuilder, ns: Blob.Mathematics, asm: Blob.Builder}
       data:
         Value:
-          id: 35
+          id: 32
     00000017:
       type: {class: Int32Builder, ns: Blob.Primitive, asm: Blob.Builder}
       data:
-        Value: 88
+        Value: 444
     00000018:
       type: {class: Int32Builder, ns: Blob.Primitive, asm: Blob.Builder}
       data:
-        Value: 99
+        Value: 555
     00000019:
-      type: {class: Int32Builder, ns: Blob.Primitive, asm: Blob.Builder}
-      data:
-        Value: 11
-    0000001A:
       type: {class: UInt64Builder, ns: Blob.Primitive, asm: Blob.Builder}
       data:
-        Value: 4445555
+        Value: 77
+    0000001A:
+      type: {class: StringBuilder, ns: Blob, asm: Blob.Builder}
+      data:
+        Value: abcd
     0000001B:
-      type: {class: StringBuilder, ns: Blob, asm: Blob.Builder}
-      data:
-        Value: 4444jjjjh
-    0000001C:
-      type: {class: StringBuilder, ns: Blob, asm: Blob.Builder}
-      data:
-        Value: ffffgggg
-    0000001D:
       type: {class: DoubleBuilder, ns: Blob.Primitive, asm: Blob.Builder}
       data:
-        Value: 202020
+        Value: 999
+    0000001C:
+      type: {class: int2Builder, ns: Blob.Mathematics, asm: Blob.Builder}
+      data:
+        Value:
+          x: 321
+          y: 123
+    0000001D:
+      type: {class: int2Builder, ns: Blob.Mathematics, asm: Blob.Builder}
+      data:
+        Value:
+          x: 212
+          y: 121
     0000001E:
-      type: {class: int2Builder, ns: Blob.Mathematics, asm: Blob.Builder}
+      type: {class: int3Builder, ns: Blob.Mathematics, asm: Blob.Builder}
       data:
         Value:
-          x: 11188
-          y: 8899
+          x: 4
+          y: 5
+          z: 6
     0000001F:
-      type: {class: int2Builder, ns: Blob.Mathematics, asm: Blob.Builder}
+      type: {class: int3Builder, ns: Blob.Mathematics, asm: Blob.Builder}
       data:
         Value:
-          x: 22233
-          y: 44555
+          x: 6
+          y: 7
+          z: 8
     00000020:
-      type: {class: int3Builder, ns: Blob.Mathematics, asm: Blob.Builder}
-      data:
-        Value:
-          x: 1
-          y: 2
-          z: 3
-    00000021:
-      type: {class: int3Builder, ns: Blob.Mathematics, asm: Blob.Builder}
-      data:
-        Value:
-          x: 7
-          y: 8
-          z: 9
-    00000022:
-      type: {class: int3Builder, ns: Blob.Mathematics, asm: Blob.Builder}
-      data:
-        Value:
-          x: 9
-          y: 8
-          z: 7
-    00000023:
       type: {class: float2Builder, ns: Blob.Mathematics, asm: Blob.Builder}
       data:
         Value:
-          x: 123
-          y: 321
+          x: 44
+          y: 55
 --- !u!4 &2106881379
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/TestBlobBuilder.cs
+++ b/Assets/TestBlobBuilder.cs
@@ -17,6 +17,7 @@ public class TestBlobBuilder : MonoBehaviour
         Debug.Log($"{nameof(SimpleData)}.{nameof(SimpleData.StringArray)} = {StringArrayToString(ref Blob.Value.StringArray)}");
         Debug.Log($"{nameof(SimpleData)}.{nameof(SimpleData.UInt)} = {Blob.Value.UInt}");
         Debug.Log($"{nameof(SimpleData)}.{nameof(SimpleData.DoublePtr)} = {Blob.Value.DoublePtr.Value}");
+        Debug.Log($"{nameof(SimpleData)}.{nameof(SimpleData.TestEnum)} = {Blob.Value.TestEnum}");
     }
 
     public static string StringArrayToString(ref BlobArray<BlobString> array)
@@ -45,6 +46,10 @@ public struct SimpleData
     public BlobArray<BlobString> StringArray;
     public uint UInt;
     public BlobPtr<double> DoublePtr;
+    public Test TestEnum;
 }
 
-public class SimpleDataBuilder : BlobDataBuilder<SimpleData> {}
+public enum Test
+{
+    Foo, Bar
+}

--- a/Assets/TestComplexBlobBuilder.cs
+++ b/Assets/TestComplexBlobBuilder.cs
@@ -37,13 +37,9 @@ public struct SimpleData2
     public BlobPtr<int3> Int3Ptr;
 }
 
-public class SimpleData2Builder : BlobDataBuilder<SimpleData2> {}
-
 public struct ComplexData
 {
     public SimpleData A;
     public SimpleData2 B;
     public MathData C;
 }
-
-public class ComplexDataBuilder : BlobDataBuilder<ComplexData> {}

--- a/Assets/TestCustomBuilder.cs
+++ b/Assets/TestCustomBuilder.cs
@@ -24,8 +24,6 @@ public struct CustomBuilderData
     [CustomBuilder(typeof(ObjectNameArray))] public BlobArray<BlobString> Objects;
 }
 
-public class CustomBuilderDataBuilder : BlobDataBuilder<CustomBuilderData> {}
-
 [Serializable, DefaultBuilder]
 public class GuidBuilder : Builder<Guid>
 {

--- a/Assets/TestMathBlobBuilder.cs
+++ b/Assets/TestMathBlobBuilder.cs
@@ -27,5 +27,3 @@ public struct MathData
     public double2x2 Double2x2;
     public BlobPtr<float2> Float2Ptr;
 }
-
-public class MathBlobDataBuilder : BlobDataBuilder<MathData> {}

--- a/Assets/TestSingleBlobBuilder.cs
+++ b/Assets/TestSingleBlobBuilder.cs
@@ -8,6 +8,7 @@ public class TestSingleBlobBuilder : MonoBehaviour
 {
     public BlobAsset<int> Int;
     public BlobAsset<BlobArray<BlobString>> StringArray;
+    public BlobAsset<BlobArray<BlobArray<BlobPtr<BlobString>>>> StringArrayArray;
     public BlobAsset<AnimationCurveBlob> AnimationCurve;
 
     public void Awake()
@@ -15,5 +16,23 @@ public class TestSingleBlobBuilder : MonoBehaviour
         Debug.Log($"{nameof(TestSingleBlobBuilder)}.{nameof(Int)} = {Int.Value}");
         Debug.Log($"{nameof(TestSingleBlobBuilder)}.{nameof(StringArray)} = {TestBlobBuilder.StringArrayToString(ref StringArray.Value)}");
         Debug.Log($"{nameof(TestSingleBlobBuilder)}.{nameof(AnimationCurve)}(0.5f) = {AnimationCurveEvaluator.Evaluate(0.5f, AnimationCurve.Reference)}");
+        Debug.Log($"{nameof(TestSingleBlobBuilder)}.{nameof(StringArrayArray)} = {StringArrayArrayToString(ref StringArrayArray.Value)}");
+    }
+
+    private static string StringArrayArrayToString(ref BlobArray<BlobArray<BlobPtr<BlobString>>> array)
+    {
+        if (array.Length == 0) return "";
+
+        var msg = "";
+        for (var i = 0; i < array.Length; i++)
+        {
+            for (var j = 0; j < array[i].Length; j++)
+            {
+                msg += array[i][j].Value.ToString();
+                msg += ",";
+            }
+            msg += "|";
+        }
+        return msg;
     }
 }

--- a/Packages/blob-editor/Editor/Blob.Editor.asmdef
+++ b/Packages/blob-editor/Editor/Blob.Editor.asmdef
@@ -2,7 +2,8 @@
     "name": "Blob.Editor",
     "rootNamespace": "",
     "references": [
-        "GUID:2128cfde978da5c44bf90b8dda521ff6"
+        "GUID:2128cfde978da5c44bf90b8dda521ff6",
+        "GUID:734d92eba21c94caba915361bd5ac177"
     ],
     "includePlatforms": [
         "Editor"

--- a/Packages/blob-editor/Editor/Drawer/BlobAssetDrawer.cs
+++ b/Packages/blob-editor/Editor/Drawer/BlobAssetDrawer.cs
@@ -1,4 +1,3 @@
-using System;
 using UnityEditor;
 using UnityEngine;
 
@@ -18,12 +17,12 @@ namespace Blob.Editor
             property.serializedObject.Update();
 
             var valueType = fieldInfo.FieldType.GenericTypeArguments[0];
-            var builderType = valueType.FindBuilderType(customBuilder: null);
+            var builderFactory = valueType.GetBuilderFactory(customBuilder: null);
             property = property.FindPropertyRelative(nameof(BlobAsset<int>.Builder));
             var builder = property.GetObject();
-            if (builder == null || builder.GetType() != builderType)
+            if (builder == null || builder.GetType() != builderFactory.BuilderType)
             {
-                property.managedReferenceValue = Activator.CreateInstance(builderType);
+                property.managedReferenceValue = builderFactory.Create();
                 property.serializedObject.ApplyModifiedPropertiesWithoutUndo();
             }
 

--- a/Packages/blob-editor/Editor/Drawer/DynamicBuilderFactoryRegister.cs
+++ b/Packages/blob-editor/Editor/Drawer/DynamicBuilderFactoryRegister.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using JetBrains.Annotations;
+using UnityEditor;
+
+namespace Blob.Editor
+{
+    public static class DynamicBuilderFactoryRegister
+    {
+        private static IReadOnlyList<IDynamicBuilderFactory> _factories;
+
+        static DynamicBuilderFactoryRegister()
+        {
+            _factories = TypeCache.GetTypesDerivedFrom<IDynamicBuilderFactory>()
+                .Where(type => !type.IsAbstract && !type.IsGenericType)
+                .Select(Activator.CreateInstance).Cast<IDynamicBuilderFactory>()
+                .OrderBy(factory => factory.Order)
+                .ToArray()
+            ;
+        }
+
+        [CanBeNull] public static object Create([NotNull] Type dataType)
+        {
+            return _factories.FirstOrDefault(f => f.IsValid(dataType))?.Create(dataType);
+        }
+
+        [CanBeNull] public static IDynamicBuilderFactory FindFactory([NotNull] Type dataType)
+        {
+            return _factories.FirstOrDefault(f => f.IsValid(dataType));
+        }
+    }
+}

--- a/Packages/blob-editor/Editor/Drawer/DynamicBuilderFactoryRegister.cs.meta
+++ b/Packages/blob-editor/Editor/Drawer/DynamicBuilderFactoryRegister.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 9fff3f23154c47f1827f8e464312e67d
+timeCreated: 1629821249

--- a/Packages/blob-editor/Editor/Drawer/EnumBuilderDrawer.cs
+++ b/Packages/blob-editor/Editor/Drawer/EnumBuilderDrawer.cs
@@ -1,0 +1,47 @@
+using System;
+using UnityEditor;
+using UnityEngine;
+
+namespace Blob.Editor
+{
+    public abstract class EnumBuilderDrawer : PropertyDrawer
+    {
+        protected abstract object GetValue(SerializedProperty property);
+        protected abstract void SetValue(SerializedProperty property, object value);
+
+        public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
+        {
+            return EditorGUIUtility.singleLineHeight;
+        }
+
+        public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+        {
+            property.serializedObject.Update();
+            var enumType = Type.GetType(property.FindPropertyRelative(nameof(DynamicEnumBuilder<int>.EnumTypeName)).stringValue);
+            var valueProperty = property.FindPropertyRelative(nameof(DynamicEnumBuilder<int>.Value));
+            var value = EditorGUI.EnumPopup(position, label, (Enum)Enum.ToObject(enumType, GetValue(valueProperty)));
+            SetValue(valueProperty, value);
+            property.serializedObject.ApplyModifiedProperties();
+        }
+    }
+
+    [CustomPropertyDrawer(typeof(DynamicByteEnumBuilder))]
+    [CustomPropertyDrawer(typeof(DynamicSByteEnumBuilder))]
+    [CustomPropertyDrawer(typeof(DynamicShortEnumBuilder))]
+    [CustomPropertyDrawer(typeof(DynamicUShortEnumBuilder))]
+    [CustomPropertyDrawer(typeof(DynamicIntEnumBuilder))]
+    [CustomPropertyDrawer(typeof(DynamicUIntEnumBuilder))]
+    public class IntEnumBuilderDrawer : EnumBuilderDrawer
+    {
+        protected override object GetValue(SerializedProperty property) => property.intValue;
+        protected override void SetValue(SerializedProperty property, object value) => property.intValue = Convert.ToInt32(value);
+    }
+
+    [CustomPropertyDrawer(typeof(DynamicLongEnumBuilder))]
+    [CustomPropertyDrawer(typeof(DynamicULongEnumBuilder))]
+    public class LongEnumBuilderDrawer : EnumBuilderDrawer
+    {
+        protected override object GetValue(SerializedProperty property) => property.longValue;
+        protected override void SetValue(SerializedProperty property, object value) => property.longValue = Convert.ToInt64(value);
+    }
+}

--- a/Packages/blob-editor/Editor/Drawer/EnumBuilderDrawer.cs.meta
+++ b/Packages/blob-editor/Editor/Drawer/EnumBuilderDrawer.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 53cfe056d95d4ca4949810c93133743b
+timeCreated: 1629825962

--- a/Packages/blob-editor/Editor/Drawer/PtrBuilderDrawer.cs
+++ b/Packages/blob-editor/Editor/Drawer/PtrBuilderDrawer.cs
@@ -1,13 +1,14 @@
 ﻿using System;
-using System.Linq;
 using UnityEditor;
 using UnityEngine;
 
 namespace Blob.Editor
 {
-    [CustomPropertyDrawer(typeof(PtrBuilder<>), useForChildren: true)]
-    public class PtrBuilderDrawer : PropertyDrawer
+    public abstract class PtrBuilderDrawer : PropertyDrawer
     {
+        protected abstract string PtrBuilderPropertyName { get; }
+        protected abstract Type BlobType(SerializedProperty property);
+
         public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
         {
             var valueProperty = ValueProperty(property);
@@ -18,18 +19,32 @@ namespace Blob.Editor
         {
             property.serializedObject.Update();
             var valueProperty = ValueProperty(property);
-            var valueType = property.GetObject().GetType().FindGenericArgumentsOf(typeof(PtrBuilder<>))[0];
-            var builderType = TypeCache.GetTypesDerivedFrom(typeof(Builder<>).MakeGenericType(valueType)).Single();
+            var valueType = BlobType(property);
+            var builderFactory = valueType.GetBuilderFactory(customBuilder: null);
             var value = valueProperty.GetObject();
-            if (value == null || value.GetType() != builderType) valueProperty.managedReferenceValue = Activator.CreateInstance(builderType);
+            if (value == null || value.GetType() != builderFactory.BuilderType) valueProperty.managedReferenceValue = builderFactory.Create();
             EditorGUI.PropertyField(position, valueProperty, label, includeChildren: true);
             property.serializedObject.ApplyModifiedProperties();
         }
 
         private SerializedProperty ValueProperty(SerializedProperty property)
         {
-            var valuePath = $"{property.propertyPath}.{nameof(PtrBuilder<int>.Value)}";
-            return property.serializedObject.FindProperty(valuePath);
+            return property.FindPropertyRelative(PtrBuilderPropertyName);
         }
+    }
+
+    [CustomPropertyDrawer(typeof(PtrBuilder<>), useForChildren: true)]
+    public class GenericBlobPtrDrawer : PtrBuilderDrawer
+    {
+        protected override string PtrBuilderPropertyName => nameof(PtrBuilder<int>.Value);
+        protected override Type BlobType(SerializedProperty property) => property.GetObject().GetType().FindGenericArgumentsOf(typeof(PtrBuilder<>))[0];
+    }
+
+    [CustomPropertyDrawer(typeof(DynamicBlobPtrDrawer))]
+    public class DynamicBlobPtrDrawer : PtrBuilderDrawer
+    {
+        protected override string PtrBuilderPropertyName => nameof(DynamicPtrBuilder.Value);
+        protected override Type BlobType(SerializedProperty property) =>
+            Type.GetType(property.FindPropertyRelative(nameof(DynamicPtrBuilder.DataType)).stringValue);
     }
 }

--- a/Packages/blob-editor/Runtime/Builder/DynamicBlobBuilderArray.cs
+++ b/Packages/blob-editor/Runtime/Builder/DynamicBlobBuilderArray.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Diagnostics;
+using Blob;
+using Unity.Assertions;
+using Unity.Collections.LowLevel.Unsafe;
+
+namespace Unity.Entities
+{
+    /// <summary>
+    /// Used by the <see cref="BlobBuilder"/> methods to reference the arrays within a blob asset.
+    /// </summary>
+    /// <remarks>Use this reference to initialize the data of a newly created <see cref="BlobArray{T}"/>.</remarks>
+    public struct BlobBuilderDynamicArray
+    {
+        private IntPtr m_data;
+        private int m_length;
+        private Type m_elementType;
+
+        /// <summary>
+        /// For internal, <see cref="BlobBuilder"/>, use only.
+        /// </summary>
+        public BlobBuilderDynamicArray(IntPtr data, int length, Type elementType)
+        {
+            m_data = data;
+            m_length = length;
+            m_elementType = elementType;
+        }
+
+        [Conditional("ENABLE_UNITY_COLLECTIONS_CHECKS")]
+        private void CheckIndexOutOfRange(int index)
+        {
+            if (0 > index || index >= m_length)
+                throw new IndexOutOfRangeException($"Index {index} is out of range of '{m_length}' Length.");
+        }
+
+        /// <summary>
+        /// Array index accessor for the elements in the array.
+        /// </summary>
+        /// <param name="index">The sequential index of an array item.</param>
+        /// <exception cref="IndexOutOfRangeException">Thrown when index is less than zero or greater than the length of the array (minus one).</exception>
+        public IntPtr this[int index]
+        {
+            get
+            {
+                CheckIndexOutOfRange(index);
+                return Utility.ArrayElementAsPtr(m_data, index, UnsafeUtility.SizeOf(m_elementType));
+            }
+        }
+
+        public unsafe void SetElementAt<T>(int index, in T value) where T : unmanaged
+        {
+            Assert.AreEqual(m_elementType, typeof(T));
+            UnsafeUtility.AsRef<T>(this[index].ToPointer()) = value;
+        }
+
+        /// <summary>
+        /// Reports the number of elements in the array.
+        /// </summary>
+        public int Length => m_length;
+
+        /// <summary>
+        /// Provides a pointer to the data stored in the array.
+        /// </summary>
+        /// <remarks>You can only call this function in an [unsafe context].
+        /// [unsafe context]: https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/unsafe-code
+        /// </remarks>
+        /// <returns>A pointer to the first element in the array.</returns>
+        public IntPtr GetUnsafePtr() => m_data;
+    }
+}

--- a/Packages/blob-editor/Runtime/Builder/DynamicBlobBuilderArray.cs.meta
+++ b/Packages/blob-editor/Runtime/Builder/DynamicBlobBuilderArray.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 6d775e0a5b6543cfa965ee9a0fa1127b
+timeCreated: 1629800012

--- a/Packages/blob-editor/Runtime/Builder/DynamicBuilders.cs
+++ b/Packages/blob-editor/Runtime/Builder/DynamicBuilders.cs
@@ -1,0 +1,155 @@
+using System;
+using System.Reflection;
+using Unity.Collections.LowLevel.Unsafe;
+using Unity.Entities;
+using UnityEngine;
+
+namespace Blob
+{
+    public interface IDynamicBuilderFactory
+    {
+        public int Order { get; }
+        public Type BuilderType { get; }
+        public bool IsValid(Type dataType);
+        public object Create(Type dataType);
+    }
+
+    public abstract class DynamicBuilderFactory<T> : IDynamicBuilderFactory where T : IBuilder
+    {
+        public virtual int Order => 0;
+        public Type BuilderType => typeof(T);
+        public abstract bool IsValid(Type dataType);
+        public abstract object Create(Type dataType);
+    }
+
+    [Serializable]
+    public class DynamicEnumBuilder<T> : IBuilder where T : unmanaged
+    {
+        public string EnumTypeName;
+        public T Value;
+
+        public unsafe void Build(BlobBuilder builder, IntPtr dataPtr)
+        {
+            UnsafeUtility.AsRef<T>(dataPtr.ToPointer()) = Value;
+        }
+
+        public class Factory<U> : DynamicBuilderFactory<U> where U : DynamicEnumBuilder<T>, new()
+        {
+            public override bool IsValid(Type dataType)
+            {
+                return dataType.IsEnum && Enum.GetUnderlyingType(dataType) == typeof(T);
+            }
+
+            public override object Create(Type dataType)
+            {
+                return new U { EnumTypeName = dataType.AssemblyQualifiedName };
+            }
+        }
+    }
+
+    public class DynamicByteEnumBuilder : DynamicEnumBuilder<byte>
+    {
+        public class Factory : Factory<DynamicByteEnumBuilder> {}
+    }
+
+    public class DynamicSByteEnumBuilder : DynamicEnumBuilder<sbyte>
+    {
+        public class Factory : Factory<DynamicSByteEnumBuilder> {}
+    }
+
+    public class DynamicShortEnumBuilder : DynamicEnumBuilder<short>
+    {
+        public class Factory : Factory<DynamicShortEnumBuilder> {}
+    }
+
+    public class DynamicUShortEnumBuilder : DynamicEnumBuilder<ushort>
+    {
+        public class Factory : Factory<DynamicUShortEnumBuilder> {}
+    }
+
+    public class DynamicIntEnumBuilder : DynamicEnumBuilder<int>
+    {
+        public class Factory : Factory<DynamicIntEnumBuilder> {}
+    }
+
+    public class DynamicUIntEnumBuilder : DynamicEnumBuilder<uint>
+    {
+        public class Factory : Factory<DynamicUIntEnumBuilder> {}
+    }
+
+    public class DynamicLongEnumBuilder : DynamicEnumBuilder<long>
+    {
+        public class Factory : Factory<DynamicLongEnumBuilder> {}
+    }
+
+    public class DynamicULongEnumBuilder : DynamicEnumBuilder<ulong>
+    {
+        public class Factory : Factory<DynamicULongEnumBuilder> {}
+    }
+
+    [Serializable]
+    public class DynamicBlobDataBuilder : IBuilder
+    {
+        public string BlobDataType;
+        public string[] FieldNames;
+        [SerializeReference, UnboxSinglePropertyBuilder, UnityDrawProperty] public IBuilder[] Builders;
+
+        public void Build(BlobBuilder builder, IntPtr dataPtr)
+        {
+            var fields = Type.GetType(BlobDataType).GetFields(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+            for (var i = 0; i < Builders.Length; i++)
+            {
+                var offset = UnsafeUtility.GetFieldOffset(fields[i]);
+                Builders[i].Build(builder, dataPtr + offset);
+            }
+        }
+
+        public class Factory : DynamicBuilderFactory<DynamicBlobDataBuilder>
+        {
+            public override int Order => 1000;
+            public override bool IsValid(Type dataType) => !dataType.IsEnum && !dataType.IsPrimitive;
+            public override object Create(Type dataType) => new DynamicBlobDataBuilder { BlobDataType = dataType.AssemblyQualifiedName };
+        }
+    }
+
+    [Serializable]
+    public class DynamicArrayBuilder : IBuilder
+    {
+        public string ArrayElementType;
+        [SerializeReference, UnboxSinglePropertyBuilder, UnityDrawProperty] public IBuilder[] Value;
+
+        public void Build(BlobBuilder builder, IntPtr dataPtr)
+        {
+            var elementType = Type.GetType(ArrayElementType);
+            var arrayBuilder = builder.AllocateDynamicArray(elementType, dataPtr, Value.Length);
+            for (var i = 0; i < Value.Length; i++) Value[i].Build(builder, arrayBuilder[i]);
+        }
+
+        public class Factory : DynamicBuilderFactory<DynamicArrayBuilder>
+        {
+            public override int Order => 100;
+            public override bool IsValid(Type dataType) => dataType.IsGenericType && dataType.GetGenericTypeDefinition() == typeof(BlobArray<>);
+            public override object Create(Type dataType) => new DynamicArrayBuilder { ArrayElementType = dataType.GenericTypeArguments[0].AssemblyQualifiedName };
+        }
+    }
+
+    [Serializable]
+    public class DynamicPtrBuilder : IBuilder
+    {
+        public string DataType;
+        [SerializeReference, UnboxSinglePropertyBuilder, UnityDrawProperty] public IBuilder Value;
+
+        public void Build(BlobBuilder builder, IntPtr dataPtr)
+        {
+            var blobPtr = builder.AllocateDynamicPtr(Type.GetType(DataType), dataPtr);
+            Value.Build(builder, blobPtr);
+        }
+
+        public class Factory : DynamicBuilderFactory<DynamicPtrBuilder>
+        {
+            public override int Order => 100;
+            public override bool IsValid(Type dataType) => dataType.IsGenericType && dataType.GetGenericTypeDefinition() == typeof(BlobPtr<>);
+            public override object Create(Type dataType) => new DynamicPtrBuilder { DataType = dataType.GenericTypeArguments[0].AssemblyQualifiedName };
+        }
+    }
+}

--- a/Packages/blob-editor/Runtime/Builder/DynamicBuilders.cs.meta
+++ b/Packages/blob-editor/Runtime/Builder/DynamicBuilders.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 8d12d0300db746058e9d3483ad2179fd
+timeCreated: 1629819348

--- a/Packages/blob-editor/Runtime/Builder/Utility.cs
+++ b/Packages/blob-editor/Runtime/Builder/Utility.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Reflection;
+using Unity.Collections.LowLevel.Unsafe;
+using Unity.Entities;
+
+namespace Blob
+{
+    public static class Utility
+    {
+        public static IntPtr ArrayElementAsPtr(IntPtr arrayDataPtr, long index, long size) => new IntPtr(arrayDataPtr.ToInt64() + index * size);
+
+        // TODO: hack into `BlobBuilder` to make some dynamic (non-generic) methods to avoid using reflection.
+        public static BlobBuilderDynamicArray AllocateDynamicArray(this BlobBuilder builder, Type elementType, IntPtr arrayPtr, int length)
+        {
+            var func = typeof(Utility).GetMethod(nameof(AllocateDynamicArray), BindingFlags.Static | BindingFlags.NonPublic);
+            return (BlobBuilderDynamicArray) func.MakeGenericMethod(elementType).Invoke(null, new object[] {builder, arrayPtr, length});
+        }
+
+        private static unsafe BlobBuilderDynamicArray AllocateDynamicArray<T>(BlobBuilder builder, IntPtr arrayPtr, int length) where T : unmanaged
+        {
+            ref var data = ref UnsafeUtility.AsRef<BlobArray<T>>(arrayPtr.ToPointer());
+            var arrayBuilder = builder.Allocate(ref data, length);
+            return new BlobBuilderDynamicArray(new IntPtr(arrayBuilder.GetUnsafePtr()), length, typeof(T));
+        }
+
+        public static IntPtr AllocateDynamicPtr(this BlobBuilder builder, Type dataType, IntPtr dataPtr)
+        {
+            var func = typeof(Utility).GetMethod(nameof(AllocateDynamicPtr), BindingFlags.Static | BindingFlags.NonPublic);
+            return (IntPtr) func.MakeGenericMethod(dataType).Invoke(null, new object[] {builder, dataPtr});
+        }
+
+        private static unsafe IntPtr AllocateDynamicPtr<T>(BlobBuilder builder, IntPtr dataPtr) where T : unmanaged
+        {
+            ref var data = ref UnsafeUtility.AsRef<BlobPtr<T>>(dataPtr.ToPointer());
+            ref var blobPtr = ref builder.Allocate(ref data);
+            return new IntPtr(UnsafeUtility.AddressOf(ref blobPtr));
+        }
+    }
+}

--- a/Packages/blob-editor/Runtime/Builder/Utility.cs.meta
+++ b/Packages/blob-editor/Runtime/Builder/Utility.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 0af04a179ef643faa8236ba4096a8ed9
+timeCreated: 1629799913

--- a/Packages/blob-editor/package.json
+++ b/Packages/blob-editor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.quabug.blob-editor",
   "description": "Inspector-editor of blob asset",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "unity": "2020.3",
   "displayName": "BlobEditor",
   "dependencies": {

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Edit `BlobAsset` in Inspector and then easily create from code.
 
-![image](https://user-images.githubusercontent.com/683655/129909694-e2a48396-3bc4-4842-9e51-9c1732a6d8af.png)
+![image](https://user-images.githubusercontent.com/683655/130668171-ea822e22-c49d-438c-b6b4-6211253df859.png)
 
 ## Upgrade Note
 ⚠️ v1.2: upgrade from version 1.1 will lose data, you should either recreate data manually or use `BlobAssetV1`
@@ -52,8 +52,6 @@ struct Blob
 {
     public int Int;
     public BlobString String;
-    
-    public class Builder : BlobDataBuilder<Blob> {}
 }
 
 public class BlobStructureComponent : MonoBehaviour


### PR DESCRIPTION
- support `enum` type.
- support `struct` without builder.
- support `BlobArray<>` with element builder only (without `ArrayBuilder`)
  e.g. `BlobArray<BlobArray<BlobArray<int>>>` is valid now with only `IntBuilder`
- support `BlobPtr<>` without `PtrBuilder`